### PR TITLE
no 'signoff' in add-commit@v9

### DIFF
--- a/.github/workflows/netlify-daily.yml
+++ b/.github/workflows/netlify-daily.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Commit changes
       uses: EndBug/add-and-commit@v9
       with:
-        add: 'exports/*.csv'
+        add: '*.csv'
         message: "[ci skip] fluxcd.io stats from netlify-analytics"
         #signoff: true
         #new_branch: netlify-stats


### PR DESCRIPTION
and the 'exports' string does not refer to any directory