### PR TITLE
netlify-daily exports to Google

### DIFF
--- a/.github/workflows/netlify-daily.yml
+++ b/.github/workflows/netlify-daily.yml
@@ -46,6 +46,9 @@ jobs:
         spreadsheet_id: ${{ secrets.google_spreadsheet_id }}
         worksheet: 0
         append_content: true
+          # The credential is from the "kingdon-flux-netlify-exporter" account in dx-kingdon project
+          # that is also known as: 'kingdon-flux-netlify-exporter@dx-kingdon.iam.gserviceaccount.com'
+          # (It has no permissions except that it has been shared the doc above, with editor access.)
         google_service_account_email: ${{ secrets.google_service_account_email }}
         google_service_account_private_key: ${{ secrets.google_service_account_private_key }}
     - uses: niklasmerz/csv-to-google-spreadsheet@master

--- a/.github/workflows/netlify-daily.yml
+++ b/.github/workflows/netlify-daily.yml
@@ -40,27 +40,27 @@ jobs:
         message: "[ci skip] fluxcd.io stats from netlify-analytics"
         #signoff: true
         #new_branch: netlify-stats
-    #- uses: niklasmerz/csv-to-google-spreadsheet@master
-    #  with:
-    #    csv_path: pageviews.csv
-    #    spreadsheet_id: ${{ secrets.google_spreadsheet_id }}
-    #    worksheet: 0
-    #    append_content: true
-    #    google_service_account_email: ${{ secrets.google_service_account_email }}
-    #    google_service_account_private_key: ${{ secrets.google_service_account_private_key }}
-    #- uses: niklasmerz/csv-to-google-spreadsheet@master
-    #  with:
-    #    csv_path: visitors.csv
-    #    spreadsheet_id: ${{ secrets.google_spreadsheet_id }}
-    #    worksheet: 1
-    #    append_content: true
-    #    google_service_account_email: ${{ secrets.google_service_account_email }}
-    #    google_service_account_private_key: ${{ secrets.google_service_account_private_key }}
-    #- uses: niklasmerz/csv-to-google-spreadsheet@master
-    #  with:
-    #    csv_path: bandwidth.csv
-    #    spreadsheet_id: ${{ secrets.google_spreadsheet_id }}
-    #    worksheet: 2
-    #    append_content: true
-    #    google_service_account_email: ${{ secrets.google_service_account_email }}
-    #    google_service_account_private_key: ${{ secrets.google_service_account_private_key }}
+    - uses: niklasmerz/csv-to-google-spreadsheet@master
+      with:
+        csv_path: pageviews.csv
+        spreadsheet_id: ${{ secrets.google_spreadsheet_id }}
+        worksheet: 0
+        append_content: true
+        google_service_account_email: ${{ secrets.google_service_account_email }}
+        google_service_account_private_key: ${{ secrets.google_service_account_private_key }}
+    - uses: niklasmerz/csv-to-google-spreadsheet@master
+      with:
+        csv_path: visitors.csv
+        spreadsheet_id: ${{ secrets.google_spreadsheet_id }}
+        worksheet: 1
+        append_content: true
+        google_service_account_email: ${{ secrets.google_service_account_email }}
+        google_service_account_private_key: ${{ secrets.google_service_account_private_key }}
+    - uses: niklasmerz/csv-to-google-spreadsheet@master
+      with:
+        csv_path: bandwidth.csv
+        spreadsheet_id: ${{ secrets.google_spreadsheet_id }}
+        worksheet: 2
+        append_content: true
+        google_service_account_email: ${{ secrets.google_service_account_email }}
+        google_service_account_private_key: ${{ secrets.google_service_account_private_key }}


### PR DESCRIPTION
I have generated a service account for Google so we can use these to export to the spreadsheet with ID:
`1cPZ8HRmqVDW5bLQ10raXM9nwPkuSUUzI-0f8eUhu_68`

If we can add this to secrets, and a key from Google (I've left this credential in the DX key vault) we should be able to see our stats accumulating in Google Drive as well as Git, which might solve some accessibility concerns out of the gate that we would otherwise have to address in another separate aggregator job.

* [ ] Secret added: `GOOGLE_SERVICE_ACCOUNT_EMAIL`
* [ ] Secret added: `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`
* [ ] Secret added: `GOOGLE_SPREADSHEET_ID`

When those three are done, please merge this and run the daily job once more!