### PR TITLE
Do stats collection from Netlify in aggregate

### DIFF
--- a/collect-stats/Gemfile
+++ b/collect-stats/Gemfile
@@ -1,0 +1,6 @@
+ruby '2.7.6'
+source 'https://rubygems.org'
+
+gem 'awesome_print', require: 'ap'
+gem 'activesupport'
+gem 'pry'

--- a/collect-stats/Gemfile.lock
+++ b/collect-stats/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.0.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    awesome_print (1.9.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.10)
+    i18n (1.10.0)
+      concurrent-ruby (~> 1.0)
+    method_source (1.0.0)
+    minitest (5.15.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport
+  awesome_print
+  pry
+
+RUBY VERSION
+   ruby 2.7.6p219
+
+BUNDLED WITH
+   2.1.4

--- a/collect-stats/collect-stats.rb
+++ b/collect-stats/collect-stats.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+
+require 'ap'
+require 'pry'
+
+require 'active_support/all'
+
+# commits_so_far = %w{03d50caa 18b2d4d6 b71353a4 62624387 128d3da5 e267f767 0773e5cf cb3feaa3 1bfa4c4e dd14c72e 1999ff43 aa3b4887 56625329 458602ad 036a5aff 8b877e28 1d51457c 3be3dc1b dbab09f2 373007bf d3c74fc6 f9b1515c 32310e84 5afe9a0a bc0c9a1f 30af67db b5b73107 79d4dce9 9a7205c9 dc38f527 0c4cd32b ec00ee72 76f446e2 73bd5f3c 23d2fcb0 2faf6f45 fe008045 3f112981 c7ac014a 97e183ce 0d062e6e f1cef3ee 92ff87e4}
+
+commits_so_far = `git log main..netlify-stats --oneline --reverse |awk '{print $1}'|grep -v 17353663`.split("\n")
+
+def fetch_from_commit(commit_hash)
+  `git co #{commit_hash}`
+  pages = File.open('pages.csv')
+  ret = {}
+  pages.lines.each do |line|
+    v = line.chomp.split(',')
+    ret[v.first] = v.last.to_i
+  end
+
+  ret
+end
+
+stats = commits_so_far.map do |c|
+  f = fetch_from_commit(c)
+  # binding.pry
+  f
+end
+
+all_stats = {}
+days_counted = 0
+
+stats.each do |stat|
+  stat.keys.each do |key|
+    if all_stats[key].nil?
+      all_stats[key] = 0
+    end
+
+    all_stats[key] += stat[key]
+  end
+
+  days_counted += 1
+end
+
+puts; puts
+
+o_hash = ActiveSupport::OrderedHash.new
+
+ordered_stats = all_stats.sort_by(&:last).reverse
+ordered_stats.map do |n|
+  o_hash[n[0]] = n[1]
+  # puts "#{n[0]}: #{n[1]}"
+end
+  
+ap o_hash
+puts; puts '---'
+puts "days_counted: #{days_counted}"

--- a/do-netlify-stats-aggr.sh
+++ b/do-netlify-stats-aggr.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+git checkout netlify-stats && git pull --ff-only
+git checkout main && git pull --ff-only
+
+bundle exec --gemfile collect-stats/Gemfile collect-stats/collect-stats.rb
+
+git checkout main


### PR DESCRIPTION
This is the laziest way to get all the Top Pages info, quick Ruby script I threw together.

Future enhancements could include going back to get older data, or some improved slicing and dicing/visualization of the data. Unfortunately what we've learned from looking over the data this once is that Netlify only provides analytics about the top 10 pages each day.

So unless something made it to the Top-10 list on at least one given day, it won't show up on this list at all.

Still, better than nothing! Here is the output from running this script today, in the future I imagine we have something better to report on aggregate statistics over arbitrary spans and this goes away completely.

```
$ ./do-netlify-stats-aggr.sh
Switched to branch 'netlify-stats'
Your branch is up to date with 'upstream/netlify-stats'.
Already up to date.
Switched to branch 'main'
...
[SNIP] - removed a bunch of noise
...
Previous HEAD position was f1cef3ee [ci skip] fluxcd.io stats from netlify-analytics
HEAD is now at 92ff87e4 [ci skip] fluxcd.io stats from netlify-analytics


{
                                                  "/" => 80339,
                                             "/docs/" => 24987,
                                "/docs/installation/" => 18940,
                                 "/docs/get-started/" => 16796,
          "/docs/components/kustomize/kustomization/" => 11653,
                "/docs/components/helm/helmreleases/" => 10913,
                         "/docs/guides/image-update/" => 8408,
                         "/docs/guides/helmreleases/" => 7402,
                                      "/docs/guides/" => 5721,
                 "/docs/guides/repository-structure/" => 4394,
                        "/docs/guides/notifications/" => 3509,
                         "/docs/guides/mozilla-sops/" => 3334,
                                             "/blog/" => 1714,
           "/docs/components/source/gitrepositories/" => 1395,
                        "/blog/2022/04/march-update/" => 790,
                "/blog/2022/04/contributing-to-flux/" => 688,
    "/blog/2022/03/flagger-adds-gateway-api-support/" => 503,
       "/blog/2022/03/flux-puts-the-git-into-gitops/" => 290,
                                   "/docs/use-cases/" => 190,
                                          "/roadmap/" => 102
}

---
days_counted: 43
Previous HEAD position was 92ff87e4 [ci skip] fluxcd.io stats from netlify-analytics
Switched to branch 'main'
Your branch is up to date with 'upstream/main'.
```

We can run this script again tomorrow and it will show 44 days of accumulated data, the day after we'd get 45... it's all based on when we started taking snapshots of this information, as it scans through each git commit we've made through automation every day, where we got the numbers from the netlify "pages" metric.

I think that Netlify actually keeps the data for longer than 30 days, we just need a way to add them to the git history that won't be too impossible to sort out later, (we could just add a script to go back and poll the rest of the days we've missed since the first of the year... depending on when we did enable analytics and how interested we are in that historical data!)

I realize this is not the easiest way to consume this information but we have limited capabilities in terms of what we can access from this API, what we've planned for, and what else has been done for us upstream already at [NiklasMerz/netlify-analytics-collector](https://github.com/NiklasMerz/netlify-analytics-collector). Most of this work was done already there.

The next obvious step to enhance would be to see how much further back we can go. I think the 30 day limitation is imposed by the GitHub action and how it works, not by Netlify's upstream API, (but I can't be sure without spending some more time on it and trying to write my own API client next. That doesn't sound like too much work, maybe one for next week...)