### PR TITLE
Fix workflows (daily, monthly, repostats)

### DIFF
--- a/.github/workflows/netlify-daily.yml
+++ b/.github/workflows/netlify-daily.yml
@@ -23,6 +23,8 @@ jobs:
         path: '*.csv'
   sheet-upload:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/netlify-monthly.yml
+++ b/.github/workflows/netlify-monthly.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   export-run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v3
     - uses: niklasmerz/netlify-analytics-collector@v2.0.0

--- a/.github/workflows/repostats.yaml
+++ b/.github/workflows/repostats.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   j1:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       matrix:
         statsRepo:
@@ -21,4 +23,4 @@ jobs:
         uses: jgehrcke/github-repo-stats@v1.4.2
         with:
           repository: ${{ matrix.statsRepo }}
-          ghtoken: ${{ secrets.BOT_GITHUB_TOKEN }}
+          ghtoken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The permission contents: write is no longer implied here

In addition, we can:
- [ ] delete the old BOT_GITHUB_TOKEN

...if everything works as expected from this PR.

(I will test this in the local fork before we merge it)